### PR TITLE
Doc: Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func main() {
 		Mu: ptr.Float64(43.07),
 		Sigma: ptr.Float64(2.42),
 	}) 
-	a1.Ordinal() // 35.81
+	ratings.Ordinal(a1) // 35.81
 }
 ```
 


### PR DESCRIPTION
[Ordinal](https://github.com/intinig/go-openskill/blob/main/rating/ordinal.go#L9) is in fact not a method of types.Rating